### PR TITLE
feat: `assertViolated` assertion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
             "Pest\\Symfony\\": "src/"
         },
         "files": [
-            "src/App.php"
+            "src/App.php",
+            "src/Validator.php"
         ]
     },
     "autoload-dev": {
@@ -35,6 +36,7 @@
     },
     "require-dev": {
         "pestphp/pest-dev-tools": "dev-master",
+        "symfony/validator": "^5.0",
         "symfony/yaml": "^5.0"
     },
     "extra": {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Symfony;
+
+use function PHPUnit\Framework\assertContains;
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertNotCount;
+use PHPUnit\Framework\ExpectationFailedException;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Asserts that $subject doesn't pass validation (or does, if $expected === false).
+ *
+ * @param bool|int|string $expected - int to assert the number of violations,
+ *                                  string to assert it contains a specific violation (format = "propertyPath: message")
+ * @param mixed           $subject  - The variable to validate
+ *
+ * @throws \Exception
+ * @phpstan-ignore-next-line
+ */
+function assertViolated($expected, $subject, ?string $propertyPath = null): void
+{
+    /** @var ValidatorInterface $validator */
+    $validator  = container()->get(ValidatorInterface::class);
+    $violations = \iterator_to_array($validator->validate($subject));
+
+    // Check against a specitic property path
+    if (null !== $propertyPath) {
+        $violations = \array_filter(
+            $violations,
+            function (ConstraintViolationInterface $violation) use ($propertyPath): bool {
+                return $propertyPath === $violation->getPropertyPath();
+            }
+        );
+    }
+
+    // Do not care about the exact number of violations
+    if (\is_bool($expected)) {
+        $expected ? assertNotCount(0, $violations) : assertCount(0, $violations);
+
+        return;
+    }
+
+    // Check the exact number of violations
+    if (\is_int($expected)) {
+        assertCount($expected, $violations);
+
+        return;
+    }
+
+    // Check a specific violation message is returned
+    $violationMessages = \array_map(
+        function (ConstraintViolationInterface $violation): string {
+            return $violation->getPropertyPath() . ': ' . $violation->getMessage();
+        },
+        $violations
+    );
+
+    try {
+        assertContains($expected, $violationMessages);
+    } catch (ExpectationFailedException $e) {
+        assertEquals([$expected], $violationMessages, 'Violation not found.');
+    }
+}

--- a/tests/app/Entity/Book.php
+++ b/tests/app/Entity/Book.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Pest\Symfony\Tests\App\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class Book
+{
+    /**
+     * @var string
+     * @Assert\Length(min=4)
+     */
+    public $name;
+
+    /**
+     * @var string
+     * @Assert\NotNull()
+     * @Assert\Isbn()
+     */
+    public $isbn;
+}

--- a/tests/plugin/ValidatorTest.php
+++ b/tests/plugin/ValidatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pest\Symfony\Tests\Plugin;
+
+use function Pest\Symfony\assertViolated;
+use Pest\Symfony\Tests\App\Entity\Book;
+
+it('asserts a subject\'s constraints have been violated', function () {
+    $book = new Book();
+    assertViolated(true, $book);
+    assertViolated(false, $book, 'name');
+    assertViolated(true, $book, 'isbn');
+    assertViolated(1, $book);
+    assertViolated(0, $book, 'name');
+    assertViolated(1, $book, 'isbn');
+    assertViolated('isbn: This value should not be null.', $book);
+    assertViolated('isbn: This value should not be null.', $book, 'isbn');
+
+    $book->name = 'foo';
+    assertViolated(true, $book);
+    assertViolated(true, $book, 'name');
+    assertViolated(true, $book, 'isbn');
+    assertViolated(2, $book);
+    assertViolated(1, $book, 'name');
+    assertViolated(1, $book, 'isbn');
+    assertViolated('isbn: This value should not be null.', $book);
+    assertViolated('isbn: This value should not be null.', $book, 'isbn');
+    assertViolated('name: This value is too short. It should have 4 characters or more.', $book, 'name');
+
+    $book->name = '1984';
+    assertViolated(true, $book);
+    assertViolated(false, $book, 'name');
+    assertViolated(true, $book, 'isbn');
+    assertViolated(1, $book);
+    assertViolated(0, $book, 'name');
+    assertViolated(1, $book, 'isbn');
+    assertViolated('isbn: This value should not be null.', $book);
+    assertViolated('isbn: This value should not be null.', $book, 'isbn');
+
+    $book->isbn = 'foobar';
+    assertViolated(true, $book);
+    assertViolated(false, $book, 'name');
+    assertViolated(true, $book, 'isbn');
+    assertViolated(1, $book);
+    assertViolated(0, $book, 'name');
+    assertViolated(1, $book, 'isbn');
+    assertViolated('isbn: This value is neither a valid ISBN-10 nor a valid ISBN-13.', $book);
+    assertViolated('isbn: This value is neither a valid ISBN-10 nor a valid ISBN-13.', $book, 'isbn');
+
+    $book->isbn = '978-0451524935';
+    assertViolated(false, $book);
+    assertViolated(false, $book, 'name');
+    assertViolated(false, $book, 'isbn');
+    assertViolated(0, $book);
+    assertViolated(0, $book, 'name');
+    assertViolated(0, $book, 'isbn');
+});


### PR DESCRIPTION
This PR adds the `assertViolated`, to ensure that the Validator component has the expected behavior.

Usage:
```php
// Asserts at least 1 constraint has been violated
assertViolated(true, $subject);

// Asserts no constraint has been violated
assertViolated(false, $subject);

// Asserts exactly 1 constraint has been violated
assertViolated(1, $subject);

// Asserts violations contain this message
assertViolated('name: This value should not be null.', $subject);
```

You can also specify a specific property to check against:
```php
// Asserts at least 1 constraint on $subject->name has been violated
assertViolated(true, $subject, 'name');

// Asserts no constraint on $subject->name has been violated
assertViolated(false, $subject, 'name');

// Asserts exactly 1 constraint on $subject->name has been violated
assertViolated(1, $subject, 'name');

// Asserts violations contain this message on $subject->name
assertViolated('name: This value should not be null.', $subject, 'name');
```

(I will create the doc entry once PR is approved)